### PR TITLE
fix ambiguous path to modules

### DIFF
--- a/src/chrome.manifest
+++ b/src/chrome.manifest
@@ -14,5 +14,5 @@ locale	{appname}	sv-SE			locale/sv-SE/
 locale	{appname}	zh-CN			locale/zh-CN/
 locale	{appname}	zh-TW			locale/zh-TW/
 
-resource hfShared /../modules/
+resource hfShared modules/
 overlay chrome://browser/content/browser.xul  chrome://httpsfinder/content/Overlay.xul


### PR DESCRIPTION
This is to fix problem which in some cases makes https-finder not
functional: it doesn't probe for HTTPS and show no prompts or errors
although its preferences are accessible.

As far as I'm aware this is safe change and other extensions often
define path to modules without prepending any paths.
