### PR TITLE
Remove unnecessary variable 'item'

### DIFF
--- a/src/content/Overlay.js
+++ b/src/content/Overlay.js
@@ -168,7 +168,7 @@ httpsfinder.Overlay = {
         for(var i=0; i < alerts.length; i++){
             var key = alerts[i];
             //If the tab contains that alert, set a timeout and removeNotification() for the auto-dismiss time.
-            if (item = window.getBrowser().getNotificationBox(browser).getNotificationWithValue(key)){
+            if (window.getBrowser().getNotificationBox(browser).getNotificationWithValue(key)){
                 setTimeout(function(){
                     httpsfinder.removeNotification(key)
                 },httpsfinder.prefs.getIntPref("alertDismissTime") * 1000);


### PR DESCRIPTION
This variable is not needed and can thus be removed.

This fixes a Bug which will print errors to Firefox error console:

```
Zeitstempel: 03.04.2014 17:02:35
Fehler: ReferenceError: assignment to undeclared variable item
Quelldatei: chrome://httpsfinder/content/Overlay.js
Zeile: 171
```

(could be translated to:)

```
Timestamp: ...
Error: ReferenceError: assignment to undeclared variable item
Source file: chrome://httpsfinder/content/Overlay.js
Line: 171
```
